### PR TITLE
Shell script

### DIFF
--- a/md-to-toc
+++ b/md-to-toc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INPUT=$1
 OUTPUT=$2

--- a/md-to-toc
+++ b/md-to-toc
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+#First argument is input filename, optional second argument is output filename
 INPUT=$1
 OUTPUT=$2
 
-#If user doesn't enter an argument (or uses "--help") print syntax example and exit script
-if [ "$1" == "--help" ] || [ -z $INPUT ] || [ -z $OUTPUT ]; then
-  echo "Usage: md-to-toc INPUT_FILE OUTPUT_FILE"
+#If user doesn't enter any arguments (or uses "--help"), then print syntax example and exit script
+if [ "$1" == "--help" ] || [ -z $INPUT ]; then
+  echo "Usage: md-to-toc INPUT_FILE (optional: OUTPUT_FILE)"
   exit 0
 fi
 
@@ -15,8 +16,17 @@ echo "##Table of Contents" > tmp
 #Append python script output (the actual table of contents) to temp file
 python md-to-toc.py $INPUT >> tmp
 
-#Create output file, formed by appending input file to temp file
-cat tmp $INPUT > $OUTPUT
+#If no second argument given, then overwrite the INPUT file with the results, clean up, and exit
+if [ -z $OUTPUT ]; then
+  cat $INPUT >> tmp
+  cat tmp > $INPUT
+  rm tmp
+  exit 0
 
-#Clean up temp file
-rm tmp
+#Otherwise write the results to OUTPUT file, clean up, and exit
+else
+  touch $OUTPUT
+  cat tmp $INPUT > $OUTPUT
+  rm tmp
+  exit 0
+fi

--- a/md-to-toc
+++ b/md-to-toc
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+INPUT=$1
+OUTPUT=$2
+
+if [ "$1" == "--help" ] || [ -z $INPUT ] || [ -z $OUTPUT ]; then
+  echo "Usage: md-to-toc INPUT_FILE OUTPUT_FILE"
+  exit 0
+fi
+
+echo "##Table of Contents" > tmp
+python md-to-toc.py $INPUT >> tmp
+cat tmp $INPUT > $OUTPUT
+rm tmp

--- a/md-to-toc
+++ b/md-to-toc
@@ -3,12 +3,20 @@
 INPUT=$1
 OUTPUT=$2
 
+#If user doesn't enter an argument (or uses "--help") print syntax example and exit script
 if [ "$1" == "--help" ] || [ -z $INPUT ] || [ -z $OUTPUT ]; then
   echo "Usage: md-to-toc INPUT_FILE OUTPUT_FILE"
   exit 0
 fi
 
+#Prepare temp file with h2 that says "Table of Contents"
 echo "##Table of Contents" > tmp
+
+#Append python script output (the actual table of contents) to temp file
 python md-to-toc.py $INPUT >> tmp
+
+#Create output file, formed by appending input file to temp file
 cat tmp $INPUT > $OUTPUT
+
+#Clean up temp file
 rm tmp

--- a/md-to-toc
+++ b/md-to-toc
@@ -14,7 +14,7 @@ fi
 echo "##Table of Contents" > tmp
 
 #Append python script output (the actual table of contents) to temp file
-python md-to-toc.py $INPUT >> tmp
+md-to-toc.py $INPUT >> tmp
 
 #If no second argument given, then overwrite the INPUT file with the results, clean up, and exit
 if [ -z $OUTPUT ]; then

--- a/md-to-toc.py
+++ b/md-to-toc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # Author: Antonio Maiorano (amaiorano@gmail.com)
 
 import sys

--- a/md-to-toc.py
+++ b/md-to-toc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Antonio Maiorano (amaiorano@gmail.com)
 
 import sys


### PR DESCRIPTION
I created a little bash script that makes using the python script a little cleaner. Adding both the shell script and the python script to the system's path should allow users to call `md-to-toc input output` from wherever their shell is, and it would work like a regular command line utility (although I haven't gotten around to testing that yet).